### PR TITLE
縫いしろ内側の点線を細かくする

### DIFF
--- a/src/js/clipper-offset.js
+++ b/src/js/clipper-offset.js
@@ -249,8 +249,8 @@ export function applySeamAllowanceWithClipper(svgElement, seamAllowance) {
             // Insert the allowance path after the original
             path.parentNode.insertBefore(allowancePath, path.nextSibling);
             
-            // Update original path style
-            path.setAttribute('stroke-dasharray', '5,5');
+            // Update original path style with finer dotted line
+            path.setAttribute('stroke-dasharray', '2,2');
         } catch (error) {
             const pathId = path.getAttribute('id') || `path-${index + 1}`;
             const errorMsg = window.i18n?.translate('seamAllowanceError', { pathId, error: error.message }) ||


### PR DESCRIPTION
## 概要
縫いしろ内側の点線（カットライン）をより細かくしました。

## 変更内容
- 点線の幅 を変更

## テスト
- 既存のE2Eテストはすべてパスしています
- 視覚的な変更のみで、機能への影響はありません