### PR TITLE
パターンシンボルラベルの視認性改善

### DIFF
--- a/src/js/pattern-symbols.js
+++ b/src/js/pattern-symbols.js
@@ -97,12 +97,14 @@ export function addSymbolToPattern(pieceElement) {
     text.setAttribute('font-size', finalFontSize);
     text.setAttribute('font-family', 'Arial, sans-serif');
     text.setAttribute('font-weight', 'bold');
-    text.setAttribute('fill', '#000000');
-    text.setAttribute('stroke', '#000000');
+    text.setAttribute('fill', '#808080');
+    text.setAttribute('stroke', '#808080');
     text.setAttribute('stroke-width', '0.5');
+    text.setAttribute('opacity', '0.5');
     text.textContent = symbol;
     
-    pieceElement.appendChild(text);
+    // Insert at the beginning of the group to place behind other elements
+    pieceElement.insertBefore(text, pieceElement.firstChild);
 }
 
 /**


### PR DESCRIPTION
## Summary
- パターンシンボルのラベルが縫いしろ線と重なって見づらくなる問題を修正
- ラベルをグレー色かつ半透明にし、縫いしろ線の背後に配置するように変更

## Changes
- ラベルの色を黒からグレー (#808080) に変更
- 透明度を0.5に設定して半透明化
- DOM配置順を変更（appendChild → insertBefore）し、要素グループの最初に配置
- これにより縫いしろ線の背後に表示されるように改善

## Test plan
✅ ユニットテスト: 全75テストがパス
✅ E2Eテスト: 全93テストがパス

🤖 Generated with [Claude Code](https://claude.ai/code)